### PR TITLE
Fix 'for' label in example

### DIFF
--- a/content/checkbox/vertical.html
+++ b/content/checkbox/vertical.html
@@ -15,10 +15,10 @@ forms: true
     </div>
     <div class="inline-flex items-center space-x-1.5">
       <input
-        id="basic"
+        id="shared"
         type="checkbox"
         class="cursor-pointer rounded border-gray-300 text-blue-600 transition focus:ring-blue-600 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:opacity-75" />
-      <label for="basic" class="cursor-pointer truncate text-xs font-medium text-gray-500"> Shared via Link </label>
+      <label for="shared" class="cursor-pointer truncate text-xs font-medium text-gray-500"> Shared via Link </label>
     </div>
     <div class="inline-flex items-center space-x-1.5">
       <input


### PR DESCRIPTION
The demo page for checkboxes has two checkboxes with id 'basic', which makes this label control the wrong checkbox: https://mynaui.com/checkbox/